### PR TITLE
Add enhanced Duolingo style notifications

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { TouchableOpacity, Modal, View, Text, SafeAreaView, StatusBar, AppState, Platform, Animated, Dimensions, Pressable } from 'react-native';
-import { NavigationContainer, DefaultTheme, DarkTheme, createNavigationContainerRef, CommonActions } from '@react-navigation/native';
+import { NavigationContainer, DefaultTheme, DarkTheme, CommonActions } from '@react-navigation/native';
+import { navigationRef } from './src/navigation/NavigationService';
+import { useEnhancedNotifications } from './src/hooks/useEnhancedNotifications';
+import * as Linking from 'expo-linking';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator } from '@react-navigation/stack';
 import { Ionicons } from '@expo/vector-icons';
@@ -88,17 +91,13 @@ type RootStackParamList = {
 };
 
 // Create a navigation ref that can be used outside of React components
-export const navigationRef = createNavigationContainerRef<RootStackParamList>();
+// Deprecated internal navigationRef; use NavigationService instead
 
 // Note: Notification handler is configured in src/utils/notifications.ts
 
 // Function to navigate from anywhere
 export function navigateFromAnywhere(name: keyof RootStackParamList, params?: any) {
-  if (navigationRef.isReady()) {
-    navigationRef.navigate(name, params);
-  } else {
-    console.error('[Global Navigation] Navigation not initialized yet');
-  }
+  navigate(name, params);
 }
 
 // Function to force navigation by resetting the stack
@@ -117,7 +116,9 @@ export function forceNavigate(name: keyof RootStackParamList, params?: any) {
 
 // Helper function to navigate from outside a navigation component (for compatibility)
 function navigate(name: keyof RootStackParamList, params?: any) {
-  navigateFromAnywhere(name, params);
+  if (navigationRef.isReady()) {
+    navigationRef.navigate(name as never, params as never);
+  }
 }
 
 // Global initialization flags to prevent multiple initializations
@@ -127,6 +128,9 @@ let isMotivationalMessagesInitialized = false;
 export default function App() {
   // Disable console logs in production
   disableConsoleLogsInProduction();
+
+  // Initialize enhanced notifications
+  const { isInitialized: notificationsReady } = useEnhancedNotifications();
   
   // Mark app start time for performance measurement
   performance.markAppStart();
@@ -160,6 +164,35 @@ export default function App() {
     };
 
     initializeVideoLoader();
+  }, []);
+
+  useEffect(() => {
+    const handleDeepLink = (url: string) => {
+      const { hostname, path, queryParams } = Linking.parse(url);
+      if (hostname === 'ai-wellness') {
+        if (path === 'voice') {
+          navigationRef.current?.navigate('AIWellnessVoice', {
+            conversationId: queryParams?.conversationId,
+            userId: queryParams?.userId,
+          });
+        } else if (path === 'chat') {
+          navigationRef.current?.navigate('AIWellnessChat', {
+            conversationId: queryParams?.conversationId,
+            userId: queryParams?.userId,
+          });
+        }
+      }
+    };
+
+    Linking.getInitialURL().then((url) => {
+      if (url) handleDeepLink(url);
+    });
+
+    const subscription = Linking.addEventListener('url', (event) => {
+      handleDeepLink(event.url);
+    });
+
+    return () => subscription.remove();
   }, []);
   
   return (

--- a/app.json
+++ b/app.json
@@ -15,9 +15,14 @@
       "buildNumber": "3",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
-        "UIBackgroundModes": ["remote-notification"],
+        "UIBackgroundModes": ["fetch", "remote-notification"],
+        "NSUserNotificationAlertStyle": "banner",
         "NSLocationWhenInUseUsageDescription": "FlexBreak uses your location to verify office worker eligibility when requested.",
         "NSMicrophoneUsageDescription": "FlexBreak needs access to your microphone for voice responses to the AI Wellness Coach."
+      },
+      "entitlements": {
+        "com.apple.developer.usernotifications.communication": true,
+        "com.apple.developer.usernotifications.time-sensitive": true
       },
       "splash": {
         "xib": "./ios/FlexBreak/SplashScreen.storyboard"
@@ -29,11 +34,15 @@
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
+      "useNextNotificationsApi": true,
       "permissions": [
         "SCHEDULE_EXACT_ALARM",
         "ACCESS_FINE_LOCATION",
         "ACCESS_COARSE_LOCATION",
-        "RECORD_AUDIO"
+        "RECORD_AUDIO",
+        "NOTIFICATIONS",
+        "VIBRATE",
+        "USE_FULL_SCREEN_INTENT"
       ],
       "versionCode": 3,
       "enableProguardInReleaseBuilds": true,
@@ -45,8 +54,12 @@
       [
         "expo-notifications",
         {
-          "icon": "./assets/images/potentialLogo2.png",
-          "color": "#ffffff"
+          "icon": "./assets/notification-icon.png",
+          "color": "#4A90E2",
+          "sounds": [
+            "./assets/sounds/AInotification1.mp3"
+          ],
+          "mode": "production"
         }
       ]
     ],

--- a/eas.json
+++ b/eas.json
@@ -42,7 +42,8 @@
       },
       "env": {
         "EXPO_PUBLIC_ENABLE_PROGUARD": "true",
-        "EXPO_PUBLIC_ENABLE_HERMES": "true"
+        "EXPO_PUBLIC_ENABLE_HERMES": "true",
+        "EXPO_PUBLIC_ENABLE_ENHANCED_NOTIFICATIONS": "true"
       }
     },
     "testflight": {

--- a/src/components/debug/TestNotifications.tsx
+++ b/src/components/debug/TestNotifications.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, ScrollView, Alert } from 'react-native';
+import { useTheme } from '../../context/ThemeContext';
+import { useEnhancedNotifications } from '../../hooks/useEnhancedNotifications';
+import { enhancedNotificationService } from '../../services/notifications/EnhancedNotificationService';
+import { useAuth } from '../../hooks/useAuth';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { KEYS } from '../../services/storageService';
+
+export const TestNotifications: React.FC = () => {
+  const { theme } = useTheme();
+  const { user } = useAuth();
+  const { sendTestNotification, cancelAllNotifications, notificationStats } = useEnhancedNotifications();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const testScenarios = [
+    {
+      title: 'Default Check-in',
+      action: async () => {
+        const userName = await AsyncStorage.getItem(KEYS.AI_WELLNESS.USER_NAME);
+        await enhancedNotificationService.createEnhancedNotification({
+          userId: user?.uid || 'test',
+          userName: userName || undefined,
+          soundType: 'default',
+        });
+      },
+    },
+    {
+      title: 'Gentle Reminder',
+      action: async () => {
+        const userName = await AsyncStorage.getItem(KEYS.AI_WELLNESS.USER_NAME);
+        await enhancedNotificationService.createEnhancedNotification({
+          userId: user?.uid || 'test',
+          userName: userName || undefined,
+          message: "No pressure! Just checking if you'd like to chat 💭",
+          soundType: 'gentle',
+        });
+      },
+    },
+    {
+      title: 'Important Message',
+      action: async () => {
+        const userName = await AsyncStorage.getItem(KEYS.AI_WELLNESS.USER_NAME);
+        await enhancedNotificationService.createEnhancedNotification({
+          userId: user?.uid || 'test',
+          userName: userName || undefined,
+          message: "Hey! It's been a while. Let's check in on your wellness! 🌟",
+          soundType: 'important',
+        });
+      },
+    },
+    {
+      title: 'Scheduled (5 seconds)',
+      action: async () => {
+        const userName = await AsyncStorage.getItem(KEYS.AI_WELLNESS.USER_NAME);
+        const fiveSecondsLater = new Date();
+        fiveSecondsLater.setSeconds(fiveSecondsLater.getSeconds() + 5);
+
+        await enhancedNotificationService.createEnhancedNotification({
+          userId: user?.uid || 'test',
+          userName: userName || undefined,
+          message: "Scheduled check-in! How are you? 📅",
+          scheduledTime: fiveSecondsLater,
+        });
+      },
+    },
+  ];
+
+  const runTest = async (test: any) => {
+    setIsLoading(true);
+    try {
+      await test.action();
+      Alert.alert('Success', `${test.title} notification sent!`);
+    } catch (error: any) {
+      Alert.alert('Error', error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text style={[styles.title, { color: theme.text }]}>Test Enhanced Notifications</Text>
+
+      {notificationStats && (
+        <View style={[styles.statsCard, { backgroundColor: theme.cardBackground }]}>
+          <Text style={[styles.statsTitle, { color: theme.text }]}>Notification Stats</Text>
+          <Text style={[styles.statsText, { color: theme.textSecondary }]}>Today: {notificationStats.today} | This Week: {notificationStats.thisWeek}</Text>
+        </View>
+      )}
+
+      <View style={styles.testGrid}>
+        {testScenarios.map((test, index) => (
+          <TouchableOpacity
+            key={index}
+            style={[styles.testButton, { backgroundColor: theme.accent }]}
+            onPress={() => runTest(test)}
+            disabled={isLoading}
+          >
+            <Text style={styles.testButtonText}>{test.title}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <TouchableOpacity
+        style={[styles.cancelButton, { borderColor: theme.border }]}
+        onPress={cancelAllNotifications}
+      >
+        <Text style={[styles.cancelButtonText, { color: theme.textSecondary }]}>Cancel All Notifications</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  statsCard: {
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 20,
+  },
+  statsTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  statsText: {
+    fontSize: 14,
+  },
+  testGrid: {
+    gap: 12,
+  },
+  testButton: {
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 12,
+    alignItems: 'center',
+  },
+  testButtonText: {
+    color: '#FFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  cancelButton: {
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    alignItems: 'center',
+    marginTop: 20,
+  },
+  cancelButtonText: {
+    fontSize: 16,
+  },
+});

--- a/src/config/debugConfig.ts
+++ b/src/config/debugConfig.ts
@@ -1,0 +1,7 @@
+export const DEBUG_CONFIG = {
+  notifications: {
+    logLevel: __DEV__ ? 'verbose' : 'error',
+    testMode: __DEV__,
+    showTestButton: __DEV__,
+  },
+};

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,0 +1,12 @@
+export const FEATURE_FLAGS = {
+  ENHANCED_NOTIFICATIONS: {
+    enabled: true,
+    platforms: {
+      ios: true,
+      android: true,
+    },
+    soundEnabled: true,
+    richContentEnabled: true,
+    testModeEnabled: __DEV__,
+  },
+};

--- a/src/hooks/useEnhancedNotifications.ts
+++ b/src/hooks/useEnhancedNotifications.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import * as Notifications from 'expo-notifications';
+import { enhancedNotificationService } from '../services/notifications/EnhancedNotificationService';
+import { notificationResponseHandler } from '../services/notifications/NotificationResponseHandler';
+import { useAuth } from './useAuth';
+import { usePremium } from './usePremium';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { KEYS } from '../services/storageService';
+
+export const useEnhancedNotifications = () => {
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [lastNotificationId, setLastNotificationId] = useState<string | null>(null);
+  const [notificationStats, setNotificationStats] = useState<any>(null);
+  const { user } = useAuth();
+  const { isPremium } = usePremium();
+  const responseHandlerRef = useRef<any>(null);
+
+  useEffect(() => {
+    const initialize = async () => {
+      if (!user) return;
+
+      // Initialize notification handlers
+      responseHandlerRef.current = notificationResponseHandler.getInstance();
+
+      // Load user preferences
+      await AsyncStorage.getItem(KEYS.AI_WELLNESS.USER_NAME);
+
+      setIsInitialized(true);
+
+      // Load notification stats
+      const stats = await enhancedNotificationService.getNotificationStats(user.uid);
+      setNotificationStats(stats);
+    };
+
+    initialize();
+  }, [user]);
+
+  const sendTestNotification = useCallback(async () => {
+    if (!user || !isInitialized) return;
+
+    try {
+      const userName = await AsyncStorage.getItem(KEYS.AI_WELLNESS.USER_NAME);
+
+      const notificationId = await enhancedNotificationService.createEnhancedNotification({
+        userId: user.uid,
+        userName: userName || undefined,
+        soundType: 'default',
+        data: {
+          isTest: true,
+          timestamp: new Date().toISOString(),
+        },
+      });
+
+      setLastNotificationId(notificationId);
+      console.log('[Test Notification] Sent:', notificationId);
+    } catch (error) {
+      console.error('[Test Notification] Error:', error);
+      throw error;
+    }
+  }, [user, isInitialized]);
+
+  const cancelAllNotifications = useCallback(async () => {
+    await enhancedNotificationService.cancelAllNotifications();
+    console.log('[Notifications] All cancelled');
+  }, []);
+
+  const refreshStats = useCallback(async () => {
+    if (!user) return;
+    const stats = await enhancedNotificationService.getNotificationStats(user.uid);
+    setNotificationStats(stats);
+  }, [user]);
+
+  return {
+    isInitialized,
+    lastNotificationId,
+    notificationStats,
+    sendTestNotification,
+    cancelAllNotifications,
+    refreshStats,
+  };
+};

--- a/src/navigation/NavigationService.ts
+++ b/src/navigation/NavigationService.ts
@@ -1,0 +1,21 @@
+import { createNavigationContainerRef, StackActions } from '@react-navigation/native';
+
+export const navigationRef = createNavigationContainerRef();
+
+export function navigate(name: string, params?: any) {
+  if (navigationRef.isReady()) {
+    navigationRef.navigate(name as never, params as never);
+  }
+}
+
+export function push(name: string, params?: any) {
+  if (navigationRef.isReady()) {
+    navigationRef.dispatch(StackActions.push(name, params));
+  }
+}
+
+export function goBack() {
+  if (navigationRef.isReady()) {
+    navigationRef.goBack();
+  }
+}

--- a/src/services/ai/aiWellnessSchedulerV2.ts
+++ b/src/services/ai/aiWellnessSchedulerV2.ts
@@ -2,6 +2,7 @@ import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { KEYS } from '../storageService';
 import { NotificationType, cancelNotificationsByType, scheduleTypedNotification } from '../../utils/notificationManager';
+import { enhancedNotificationService } from '../notifications/EnhancedNotificationService';
 import { canScheduleNotifications, markScheduled } from './notificationDebouncer';
 import { generatePersonalizedNotification, generateDefaultNotification } from './notificationMessages';
 
@@ -244,25 +245,40 @@ export async function scheduleRegularCheckIns(isPremium: boolean, userId: string
       notificationMessage = generateDefaultNotification(userName);
     }
     
-    const notificationId = await scheduleTypedNotification(
-      {
-        title: notificationMessage.title,
-        body: notificationMessage.body,
-        sound: true,
-        data: { 
-          userId,
-          scheduledFor: scheduledDate.toISOString(),
-          dayOfWeek: day,
-          type: 'ai_wellness_checkin'  // Add explicit type
+    const notificationId = await enhancedNotificationService.createEnhancedNotification({
+      userId,
+      userName: userName || undefined,
+      message: notificationMessage.body,
+      scheduledTime: scheduledDate,
+      soundType: 'default',
+      data: {
+        dayOfWeek: day,
+        scheduledFor: scheduledDate.toISOString(),
+        isPremium,
+        category: 'ai_wellness',
+      },
+    }).catch(async (error) => {
+      console.error('[AI Scheduler] Failed to create enhanced notification:', error);
+      return scheduleTypedNotification(
+        {
+          title: notificationMessage.title,
+          body: notificationMessage.body,
+          sound: true,
+          data: {
+            userId,
+            scheduledFor: scheduledDate.toISOString(),
+            dayOfWeek: day,
+            type: 'ai_wellness_checkin'
+          },
+          categoryIdentifier: 'AI_WELLNESS_SIMPLE' as any,
         },
-        categoryIdentifier: 'AI_WELLNESS_SIMPLE' as any,
-      },
-      {
-        date: scheduledDate,  // Use date trigger like motivational messages
-        type: Notifications.SchedulableTriggerInputTypes.DATE
-      },
-      NotificationType.AI_WELLNESS
-    );
+        {
+          date: scheduledDate,
+          type: Notifications.SchedulableTriggerInputTypes.DATE,
+        },
+        NotificationType.AI_WELLNESS
+      );
+    });
     
     console.log(`✅ Scheduled check-in for ${getDayName(day)} at ${scheduledDate.toLocaleString()} with ID ${notificationId}`);
     console.log(`   Message: "${notificationMessage.title}" - "${notificationMessage.body}"`);
@@ -359,6 +375,26 @@ export async function debugAIWellnessNotifications() {
   
   return aiNotifications;
 }
+
+export const triggerImmediateWellnessCheckIn = async (userId: string, userName?: string) => {
+  try {
+    const notificationId = await enhancedNotificationService.createEnhancedNotification({
+      userId,
+      userName,
+      soundType: 'default',
+      data: {
+        triggered: 'manual',
+        timestamp: new Date().toISOString(),
+      },
+    });
+
+    console.log('[AI Scheduler] Immediate check-in triggered:', notificationId);
+    return notificationId;
+  } catch (error) {
+    console.error('[AI Scheduler] Failed to trigger immediate check-in:', error);
+    throw error;
+  }
+};
 
 function getNextWeekdayTrigger(
   targetDay: number, 

--- a/src/services/notifications/AndroidEnhancements.ts
+++ b/src/services/notifications/AndroidEnhancements.ts
@@ -1,0 +1,28 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+
+export const enhanceAndroidNotification = async (
+  content: Notifications.NotificationContentInput
+): Promise<Notifications.NotificationContentInput> => {
+  if (Platform.OS !== 'android') return content;
+
+  return {
+    ...content,
+    pressAction: {
+      id: 'default',
+      launchActivity: 'default',
+    },
+    allowBubbles: true,
+    shortcutId: 'ai-wellness-coach',
+    contextualActions: [
+      {
+        title: 'Snooze 1 hour',
+        actionId: 'snooze_1h',
+      },
+      {
+        title: 'Turn off for today',
+        actionId: 'disable_today',
+      },
+    ],
+  } as any;
+};

--- a/src/services/notifications/EnhancedNotificationService.ts
+++ b/src/services/notifications/EnhancedNotificationService.ts
@@ -1,0 +1,382 @@
+import * as Notifications from 'expo-notifications';
+import * as Device from 'expo-device';
+import { Platform } from 'react-native';
+import Constants from 'expo-constants';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// Configure notification handler
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: true,
+    priority: Notifications.AndroidNotificationPriority.HIGH,
+  }),
+});
+
+export interface EnhancedNotificationConfig {
+  userId: string;
+  userName?: string;
+  message?: string;
+  conversationId?: string;
+  soundType?: 'default' | 'gentle' | 'important';
+  scheduledTime?: Date;
+  data?: any;
+}
+
+export class EnhancedNotificationService {
+  private static instance: EnhancedNotificationService;
+  private notificationMessages: string[] = [
+    "How's your day going? Let's do a quick wellness check! 🌟",
+    'Time for a mindful moment! How are you feeling? 💭',
+    'Hey there! Ready for your wellness check-in? 🌈',
+    "Let's take a moment to check in on your well-being! ✨",
+    "Your AI coach is here! How's everything today? 🤗",
+    "Quick check-in time! How's your body feeling? 💪",
+    'Hello! Let\'s see how you\'re doing today! 🌺',
+    'Wellness check! How are you managing today? 🎯',
+    "Time to connect! How's your energy level? ⚡",
+    "Hey! Let's chat about how you're feeling! 💬",
+  ];
+
+  private constructor() {
+    this.initialize();
+  }
+
+  static getInstance(): EnhancedNotificationService {
+    if (!this.instance) {
+      this.instance = new EnhancedNotificationService();
+    }
+    return this.instance;
+  }
+
+  private async initialize() {
+    // Request permissions
+    await this.requestPermissions();
+
+    // Register notification categories for iOS
+    if (Platform.OS === 'ios') {
+      await this.setupIOSCategories();
+    }
+
+    // Setup notification channels for Android
+    if (Platform.OS === 'android') {
+      await this.setupAndroidChannels();
+    }
+  }
+
+  private async requestPermissions(): Promise<boolean> {
+    if (!Device.isDevice) {
+      console.log('Notifications only work on physical devices');
+      return false;
+    }
+
+    const { status: existingStatus } = await Notifications.getPermissionsAsync();
+    let finalStatus = existingStatus;
+
+    if (existingStatus !== 'granted') {
+      const { status } = await Notifications.requestPermissionsAsync({
+        ios: {
+          allowAlert: true,
+          allowBadge: true,
+          allowSound: true,
+          allowAnnouncements: true,
+          allowCriticalAlerts: true,
+        },
+      });
+      finalStatus = status;
+    }
+
+    if (finalStatus !== 'granted') {
+      console.warn('Push notification permissions not granted');
+      return false;
+    }
+
+    return true;
+  }
+
+  private async setupIOSCategories() {
+    await Notifications.setNotificationCategoryAsync('AI_WELLNESS_ENHANCED', [
+      {
+        identifier: 'reply',
+        buttonTitle: '💬 Reply',
+        options: {
+          isAuthenticationRequired: false,
+          opensAppToForeground: false,
+        },
+        textInput: {
+          submitButtonTitle: 'Send',
+          placeholder: 'How are you feeling?',
+        },
+      },
+      {
+        identifier: 'voice',
+        buttonTitle: '🎤 Voice Reply',
+        options: {
+          opensAppToForeground: true,
+        },
+      },
+      {
+        identifier: 'later',
+        buttonTitle: '⏰ Later',
+        options: {
+          isDestructive: true,
+        },
+      },
+    ]);
+  }
+
+  private async setupAndroidChannels() {
+    // High priority channel for wellness notifications
+    await Notifications.setNotificationChannelAsync('ai-wellness-enhanced', {
+      name: 'AI Wellness Coach',
+      description: 'Personalized wellness check-ins from your AI coach',
+      importance: Notifications.AndroidImportance.HIGH,
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: '#4A90E2',
+      enableLights: true,
+      enableVibrate: true,
+      showBadge: true,
+      bypassDnd: false,
+      lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+      sound: 'AInotification1.mp3',
+    });
+
+    // Gentle reminder channel (also uses the same sound)
+    await Notifications.setNotificationChannelAsync('ai-wellness-gentle', {
+      name: 'Gentle Reminders',
+      description: 'Soft wellness reminders',
+      importance: Notifications.AndroidImportance.DEFAULT,
+      vibrationPattern: [0, 100],
+      sound: 'AInotification1.mp3',
+    });
+  }
+
+  async createEnhancedNotification(config: EnhancedNotificationConfig): Promise<string> {
+    const conversationId = config.conversationId || this.generateId();
+    const message = config.message || this.getRandomMessage();
+    const userName = config.userName;
+
+    // Build personalized greeting
+    const greeting = userName ? `Hey ${userName}! 👋` : 'Hey there! 👋';
+
+    // Store conversation context
+    await this.storeConversationContext({
+      conversationId,
+      userId: config.userId,
+      userName,
+      initialMessage: message,
+      timestamp: new Date().toISOString(),
+    });
+
+    // Create notification content
+    const content = await this.buildNotificationContent({
+      greeting,
+      message,
+      conversationId,
+      userId: config.userId,
+      soundType: config.soundType || 'default',
+      data: config.data,
+    });
+
+    // Schedule notification
+    const trigger = config.scheduledTime
+      ? { date: config.scheduledTime }
+      : null; // Immediate
+
+    const notificationId = await Notifications.scheduleNotificationAsync({
+      content,
+      trigger,
+    });
+
+    console.log('[Enhanced Notification] Created:', notificationId);
+    return notificationId;
+  }
+
+  private async buildNotificationContent(params: {
+    greeting: string;
+    message: string;
+    conversationId: string;
+    userId: string;
+    soundType: string;
+    data?: any;
+  }): Promise<Notifications.NotificationContentInput> {
+    const { greeting, message, conversationId, userId, soundType, data } = params;
+
+    const baseContent: Notifications.NotificationContentInput = {
+      title: '🤖 AI Flex Coach',
+      subtitle: greeting,
+      body: message,
+      data: {
+        ...data,
+        type: 'AI_WELLNESS_ENHANCED',
+        conversationId,
+        userId,
+      },
+      badge: 1,
+    };
+
+    // Platform-specific enhancements
+    if (Platform.OS === 'ios') {
+      return this.buildIOSContent(baseContent, soundType);
+    } else {
+      return this.buildAndroidContent(baseContent, greeting, message);
+    }
+  }
+
+  private buildIOSContent(
+    baseContent: Notifications.NotificationContentInput,
+    soundType: string
+  ): Notifications.NotificationContentInput {
+    return {
+      ...baseContent,
+      categoryIdentifier: 'AI_WELLNESS_ENHANCED',
+      sound: this.getSound(soundType),
+      interruptionLevel: 'timeSensitive',
+      relevanceScore: 1.0,
+      launchImageName: 'SplashScreen',
+      // iOS 15+ Communication Notification (shows larger)
+      _displayInCarPlay: false,
+      _displayInList: true,
+      _displayAsAlert: true,
+    };
+  }
+
+  private buildAndroidContent(
+    baseContent: Notifications.NotificationContentInput,
+    greeting: string,
+    message: string
+  ): Notifications.NotificationContentInput {
+    return {
+      ...baseContent,
+      channelId: 'ai-wellness-enhanced',
+      priority: Notifications.AndroidNotificationPriority.HIGH,
+      vibrate: [0, 250, 250, 250],
+      color: '#4A90E2',
+      autoDismiss: false,
+      sticky: false,
+      // Android-specific styling
+      largeIcon: 'https://flexbreak.app/assets/ai-coach-large-icon.png',
+      // Enable expanded notification
+      _displayInForeground: true,
+      // Custom layout appearance
+      androidMode: Notifications.AndroidNotificationChannelMode.IRRELEVANT,
+      // Big Text Style
+      style: {
+        type: 'bigText',
+        title: baseContent.title,
+        subtitle: greeting,
+        body: message,
+        summaryText: 'Tap to start your wellness check-in',
+      },
+    } as Notifications.NotificationContentInput;
+  }
+
+  private getSound(type: string): string | Notifications.NotificationSound {
+    // Always use the custom AI notification sound
+    if (Platform.OS === 'ios') {
+      return {
+        shouldPlay: true,
+        name: 'AInotification1.mp3',
+        volume: type === 'gentle' ? 0.5 : 0.8,
+        critical: false,
+      };
+    } else {
+      // Android - just return the filename
+      return 'AInotification1.mp3';
+    }
+  }
+
+  private getRandomMessage(): string {
+    const randomIndex = Math.floor(Math.random() * this.notificationMessages.length);
+    return this.notificationMessages[randomIndex];
+  }
+
+  private generateId(): string {
+    return Date.now().toString(36) + Math.random().toString(36).substr(2);
+  }
+
+  private async storeConversationContext(context: any) {
+    const key = `@enhanced_notification_${context.conversationId}`;
+    await AsyncStorage.setItem(key, JSON.stringify(context));
+  }
+
+  async handleNotificationResponse(response: Notifications.NotificationResponse) {
+    const { notification, actionIdentifier, userText } = response;
+    const data = notification.request.content.data as any;
+
+    if (data?.type !== 'AI_WELLNESS_ENHANCED') return;
+
+    console.log('[Enhanced Notification] Response:', actionIdentifier, userText);
+
+    switch (actionIdentifier) {
+      case 'reply':
+        if (userText) {
+          await this.handleTextReply(data.conversationId, data.userId, userText);
+        }
+        break;
+      case 'voice':
+        // Deep link to voice mode
+        await this.openVoiceMode(data.conversationId, data.userId);
+        break;
+      case 'later':
+        // Simply log for now
+        console.log('User chose to handle later');
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async handleTextReply(conversationId: string, userId: string, text: string) {
+    const key = `@enhanced_notification_${conversationId}_reply`;
+    await AsyncStorage.setItem(key, JSON.stringify({ userId, text, timestamp: Date.now() }));
+  }
+
+  private async openVoiceMode(conversationId: string, userId: string) {
+    const url = `flexbreak-app://ai-wellness/voice?conversationId=${conversationId}&userId=${userId}`;
+    await Notifications.dismissAllNotificationsAsync();
+    await Notifications.scheduleNotificationAsync({
+      content: {
+        title: 'Opening voice mode...'
+      },
+      trigger: null,
+    });
+    if (typeof Linking !== 'undefined') {
+      // Ensure Linking is loaded lazily
+      const { default: LinkingModule } = await import('expo-linking');
+      LinkingModule.openURL(url);
+    }
+  }
+
+  async cancelAllNotifications() {
+    await Notifications.cancelAllScheduledNotificationsAsync();
+  }
+
+  async getNotificationStats(userId: string) {
+    const keys = await AsyncStorage.getAllKeys();
+    const notificationKeys = keys.filter((k) => k.startsWith('@enhanced_notification_'));
+    const stats = {
+      today: 0,
+      thisWeek: 0,
+    } as { today: number; thisWeek: number };
+
+    const now = new Date();
+    const todayStart = new Date(now.setHours(0, 0, 0, 0));
+    const weekStart = new Date(now.setDate(now.getDate() - 7));
+
+    for (const key of notificationKeys) {
+      const data = await AsyncStorage.getItem(key);
+      if (data) {
+        const notification = JSON.parse(data);
+        const timestamp = new Date(notification.timestamp);
+        if (timestamp >= todayStart) stats.today++;
+        if (timestamp >= weekStart) stats.thisWeek++;
+      }
+    }
+
+    return stats;
+  }
+}
+
+export const enhancedNotificationService = EnhancedNotificationService.getInstance();

--- a/src/services/notifications/IOSEnhancements.ts
+++ b/src/services/notifications/IOSEnhancements.ts
@@ -1,0 +1,18 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+
+export const enhanceIOSNotification = async (
+  content: Notifications.NotificationContentInput
+): Promise<Notifications.NotificationContentInput> => {
+  if (Platform.OS !== 'ios') return content;
+
+  return {
+    ...content,
+    interruptionLevel: 'timeSensitive',
+    relevanceScore: 1.0,
+    targetContentIdentifier: 'ai-wellness-checkin',
+    threadIdentifier: 'ai-wellness',
+    summaryArgument: 'AI Wellness Check-in',
+    summaryArgumentCount: 1,
+  };
+};

--- a/src/services/notifications/NotificationResponseHandler.ts
+++ b/src/services/notifications/NotificationResponseHandler.ts
@@ -1,0 +1,60 @@
+import * as Notifications from 'expo-notifications';
+import { enhancedNotificationService } from './EnhancedNotificationService';
+import { navigationRef } from '../../navigation/NavigationService';
+
+export class NotificationResponseHandler {
+  private static instance: NotificationResponseHandler;
+
+  private constructor() {
+    this.setupListeners();
+  }
+
+  static getInstance(): NotificationResponseHandler {
+    if (!this.instance) {
+      this.instance = new NotificationResponseHandler();
+    }
+    return this.instance;
+  }
+
+  private setupListeners() {
+    // Handle notifications when app is in foreground
+    Notifications.addNotificationReceivedListener(this.handleNotificationReceived);
+
+    // Handle notification interactions
+    Notifications.addNotificationResponseReceivedListener(this.handleNotificationResponse);
+  }
+
+  private handleNotificationReceived = (notification: Notifications.Notification) => {
+    console.log('[Notification Received]', notification);
+
+    const data = notification.request.content.data;
+    if (data?.type === 'AI_WELLNESS_ENHANCED') {
+      // Additional in-app handling could be done here
+    }
+  };
+
+  private handleNotificationResponse = async (
+    response: Notifications.NotificationResponse
+  ) => {
+    console.log('[Notification Response]', response);
+
+    // Delegate to enhanced notification service
+    await enhancedNotificationService.handleNotificationResponse(response);
+
+    const data = response.notification.request.content.data as any;
+    if (data?.type === 'AI_WELLNESS_ENHANCED') {
+      if (response.actionIdentifier === 'voice') {
+        navigationRef.current?.navigate('AIWellnessVoice', {
+          conversationId: data.conversationId,
+          mode: 'voice',
+        });
+      } else if (response.actionIdentifier === Notifications.DEFAULT_ACTION_IDENTIFIER) {
+        navigationRef.current?.navigate('AIWellnessChat', {
+          conversationId: data.conversationId,
+        });
+      }
+    }
+  };
+}
+
+export const notificationResponseHandler = NotificationResponseHandler.getInstance();


### PR DESCRIPTION
## Summary
- configure Expo notifications plugin and permissions
- enable enhanced notifications in production builds
- implement `EnhancedNotificationService` and response handling
- add hooks, navigation service, and debug component
- integrate scheduler with new notifications

## Testing
- `npm run type-check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6862a50f32008325bae88038e898b176